### PR TITLE
Fixing accidentally removed trackEvent method for Android

### DIFF
--- a/lib/module/analytics/tracking.js
+++ b/lib/module/analytics/tracking.js
@@ -1,13 +1,21 @@
 // tracking.js
 'use strict';
-import { NativeModules } from 'react-native';
+import { NativeModules, Platform } from 'react-native';
 
 const AccTracking = NativeModules.RNAccTracking;
 
 class Tracking {
 
+    trackEvent(id, parameters) {
+        AccTracking.trackEvent(id, parameters);
+    }
+
     trackCustomEvent(id, parameters) {
-        AccTracking.trackCustomEvent(id, parameters);
+        if (Platform.OS === 'ios') {
+            AccTracking.trackCustomEvent(id, parameters);
+        } else if (Platform.OS === 'android') {
+            AccTracking.trackEvent(id, parameters);
+        }
     }
 
     trackLead(key, value) {


### PR DESCRIPTION
Context : https://accengage.freshdesk.com/a/tickets/14636
Method track event was accidentally removed from the last React release.
I re-added "trackEvent" method for Android and iOS, and also modified "trackCustomEvent" to allow Android users to use it.