### PR TITLE
Add vendored frameworks and React dep in Podspec

### DIFF
--- a/ios/RNAcc.podspec
+++ b/ios/RNAcc.podspec
@@ -23,7 +23,7 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/Accengage/accengage-mobile-react-native.git", :tag => "master" }
   s.source_files  = "RNAcc/**/*.{h,m}"
   s.requires_arc = true
+  s.ios.vendored_frameworks = "Frameworks/Accengage.framework"
+  s.dependency "React"
 
 end
-
-  


### PR DESCRIPTION
When adding the lib to a project using CocoaPods, some React headers are missing with react-native 0.60.0