### PR TITLE
Replace compile by implementation in Gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -33,7 +33,7 @@ repositories {
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:+'
-    compile 'com.ad4screen.sdk:A4SSDK:3.8.6'
+    implementation 'com.facebook.react:react-native:+'
+    implementation 'com.ad4screen.sdk:A4SSDK:3.8.6'
 }
   


### PR DESCRIPTION
In order to remove this warning when compiling

> Configure project :react-native-acc
WARNING: Configuration 'compile' is obsolete and has been replaced with 'implementation' and 'api'.
It will be removed at the end of 2018. For more information see: http://d.android.com/r/tools/update-dependency-configurations.html